### PR TITLE
Save multiple files with the same name

### DIFF
--- a/src/crap.nim
+++ b/src/crap.nim
@@ -13,10 +13,10 @@ proc crap*(path: string) =
   else:
     getHomeDir() / ".local/share/Trash"
 
-  if existsFile(trashHome / "files" / fname):
-    var i = 1
+  if existsFile(trashHome / "files" / fname) or existsDir(trashHome / "files" / fname):
+    var i = 2
     while true:
-      if not existsFile(trashHome / "files" / fname & '.' & $i):
+      if not (existsFile(trashHome / "files" / fname & '.' & $i) or existsDir(trashHome / "files" / fname & '.' & $i) ):
         fname = fname & '.' & $i
         moveFile(fullPath, trashHome / "files" / fname)
         break

--- a/src/crap.nim
+++ b/src/crap.nim
@@ -5,15 +5,24 @@ import
   times
 
 proc crap*(path: string) =
-  let fullPath = expandFilename(path)
-  let fname = extractFilename(fullPath)
+  var fullPath = expandFilename(path)
+  var fname = extractFilename(fullPath)
 
   let trashHome = if existsEnv("XDG_DATA_HOME"):
     getEnv("XDG_DATA_HOME") / "Trash"
   else:
     getHomeDir() / ".local/share/Trash"
 
-  moveFile(fullPath, trashHome / "files" / fname)
+  if existsFile(trashHome / "files" / fname):
+    var i = 1
+    while true:
+      if not existsFile(trashHome / "files" / fname & '.' & $i):
+        fname = fname & '.' & $i
+        moveFile(fullPath, trashHome / "files" / fname)
+        break
+      i = i+1
+  else:
+    moveFile(fullPath, trashHome / "files" / fname)
 
   let 
     t = getTime()


### PR DESCRIPTION
If you delete a file with the same name as another file in your trashHome dir crap will simply replace the old file with the one.
This behaviour isn't what most users would expect.
This patch allow crap to save multiple files with the same name in the same way that most linux gui file managers deal with the trash.